### PR TITLE
Added support for Polymorphic Relationships to Hydrator

### DIFF
--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -137,6 +137,11 @@ class ItemHydrator
         }
     }
 
+    /**
+     * @param array                                   $attributes
+     * @param \Swis\JsonApi\Relations\MorphToRelation $relation
+     * @param string                                  $availableRelation
+     */
     protected function hydrateMorphToRelation(
         array $attributes,
         MorphToRelation $relation,

--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -144,12 +144,11 @@ class ItemHydrator
      * @param array                                   $attributes
      * @param \Swis\JsonApi\Relations\MorphToRelation $relation
      * @param string                                  $availableRelation
+     *
+     * @throws \InvalidArgumentException
      */
-    protected function hydrateMorphToRelation(
-        array $attributes,
-        MorphToRelation $relation,
-        string $availableRelation
-    ) {
+    protected function hydrateMorphToRelation(array $attributes, MorphToRelation $relation, string $availableRelation)
+    {
         if (!array_key_exists('type', $attributes[$availableRelation])) {
             throw new \InvalidArgumentException('Always provide a "type" attribute in a morphTo relationship');
         }
@@ -159,9 +158,9 @@ class ItemHydrator
     }
 
     /**
-     * @param array                                   $attributes
-     * @param string                                  $availableRelation
-     * @param \Swis\JsonApi\Relations\HasManyRelation $relation
+     * @param array                                       $attributes
+     * @param \Swis\JsonApi\Relations\MorphToManyRelation $relation
+     * @param string                                      $availableRelation
      *
      * @throws \InvalidArgumentException
      */
@@ -180,16 +179,14 @@ class ItemHydrator
     /**
      * @param \Swis\JsonApi\Interfaces\RelationInterface $relation
      * @param array                                      $relationData
-     * @param string|null                                $relatedType
+     * @param string|null                                $type
      *
      * @return \Swis\JsonApi\Items\JenssegersItem
      */
-    protected function buildRelationItem(RelationInterface $relation, array $relationData, string $relatedType = null): JenssegersItem
+    protected function buildRelationItem(RelationInterface $relation, array $relationData, string $type = null): JenssegersItem
     {
         // Sometimes the relatedType is provided from the relationship, but not always (i.e. Polymorphic Relationships)
-        if ($relatedType) {
-            $type = $relatedType;
-        } else {
+        if (null === $type) {
             $type = $relation->getType();
         }
 

--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -8,6 +8,7 @@ use Swis\JsonApi\Interfaces\ItemInterface;
 use Swis\JsonApi\Interfaces\RelationInterface;
 use Swis\JsonApi\Relations\HasManyRelation;
 use Swis\JsonApi\Relations\HasOneRelation;
+use Swis\JsonApi\Relations\MorphToManyRelation;
 use Swis\JsonApi\Relations\MorphToRelation;
 
 class JenssegersItem extends Model implements ItemInterface
@@ -159,6 +160,16 @@ class JenssegersItem extends Model implements ItemInterface
                         'id'   => $relationship->getIncluded()->getId(),
                     ],
                 ];
+            } elseif ($relationship instanceof MorphToManyRelation) {
+                $relationships[$name]['data'] = [];
+
+                foreach ($relationship->getIncluded() as $item) {
+                    $relationships[$name]['data'][] =
+                        [
+                            'type' => $item->getType(),
+                            'id'   => $item->getId(),
+                        ];
+                }
             }
 
         }
@@ -321,7 +332,6 @@ class JenssegersItem extends Model implements ItemInterface
     /**
      * Create a singular relation to another item.
      *
-     * @param string      $class
      * @param string|null $relationName
      *
      * @return \Swis\JsonApi\Relations\HasOneRelation
@@ -332,6 +342,25 @@ class JenssegersItem extends Model implements ItemInterface
 
         if (!array_key_exists($relationName, $this->relationships)) {
             $this->relationships[$relationName] = new MorphToRelation($this);
+        }
+
+        return $this->relationships[$relationName];
+    }
+
+
+    /**
+     * Create a singular relation to another item.
+     *
+     * @param string|null $relationName
+     *
+     * @return \Swis\JsonApi\Relations\MorphToManyRelation
+     */
+    public function morphToMany(string $relationName = null)
+    {
+        $relationName = $relationName ?: snake_case(debug_backtrace()[1]['function']);
+
+        if (!array_key_exists($relationName, $this->relationships)) {
+            $this->relationships[$relationName] = new MorphToManyRelation();
         }
 
         return $this->relationships[$relationName];

--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -8,6 +8,7 @@ use Swis\JsonApi\Interfaces\ItemInterface;
 use Swis\JsonApi\Interfaces\RelationInterface;
 use Swis\JsonApi\Relations\HasManyRelation;
 use Swis\JsonApi\Relations\HasOneRelation;
+use Swis\JsonApi\Relations\MorphToRelation;
 
 class JenssegersItem extends Model implements ItemInterface
 {
@@ -151,7 +152,15 @@ class JenssegersItem extends Model implements ItemInterface
                             'id'   => $item->getId(),
                         ];
                 }
+            } elseif ($relationship instanceof MorphToRelation) {
+                $relationships[$name] = [
+                    'data' => [
+                        'type' => $relationship->getIncluded()->getType(),
+                        'id'   => $relationship->getIncluded()->getId(),
+                    ],
+                ];
             }
+
         }
 
         return $relationships;
@@ -304,6 +313,25 @@ class JenssegersItem extends Model implements ItemInterface
 
         if (!array_key_exists($relationName, $this->relationships)) {
             $this->relationships[$relationName] = new HasManyRelation($itemType);
+        }
+
+        return $this->relationships[$relationName];
+    }
+
+    /**
+     * Create a singular relation to another item.
+     *
+     * @param string      $class
+     * @param string|null $relationName
+     *
+     * @return \Swis\JsonApi\Relations\HasOneRelation
+     */
+    public function morphTo(string $relationName = null)
+    {
+        $relationName = $relationName ?: snake_case(debug_backtrace()[1]['function']);
+
+        if (!array_key_exists($relationName, $this->relationships)) {
+            $this->relationships[$relationName] = new MorphToRelation($this);
         }
 
         return $this->relationships[$relationName];

--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -310,7 +310,7 @@ class JenssegersItem extends Model implements ItemInterface
     }
 
     /**
-     * Create a singular relation to another item.
+     * Create a plural relation to another item.
      *
      * @param string      $class
      * @param string|null $relationName
@@ -334,7 +334,7 @@ class JenssegersItem extends Model implements ItemInterface
      *
      * @param string|null $relationName
      *
-     * @return \Swis\JsonApi\Relations\HasOneRelation
+     * @return \Swis\JsonApi\Relations\MorphToRelation
      */
     public function morphTo(string $relationName = null)
     {
@@ -349,7 +349,7 @@ class JenssegersItem extends Model implements ItemInterface
 
 
     /**
-     * Create a singular relation to another item.
+     * Create a plural relation to another item.
      *
      * @param string|null $relationName
      *

--- a/src/Relations/MorphToManyRelation.php
+++ b/src/Relations/MorphToManyRelation.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Swis\JsonApi\Relations;
+
+use Swis\JsonApi\Collection;
+use Swis\JsonApi\Interfaces\DataInterface;
+use Swis\JsonApi\Interfaces\RelationInterface;
+
+class MorphToManyRelation implements RelationInterface
+{
+    /** @var \Swis\JsonApi\Collection */
+    protected $included;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var bool
+     */
+    protected $omitIncluded = false;
+
+
+    public function getType(): string
+    {
+        throw new \LogicException('Type is not set in a MorphToMany-relationships');
+    }
+
+    /**
+     * Sort the included collection by the given key.
+     * You can also pass your own callback to determine how to sort the collection values.
+     *
+     * @param callable $callback
+     * @param int      $options
+     * @param bool     $descending
+     *
+     * @return self
+     */
+    public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
+    {
+        // Included may be empty when defining the relation (on the item),
+        // but will be filled when using the relation to fetch the data.
+        // Checking if we have included items and applying the order is
+        // simpler then keeping track of the sorts and applying them later.
+        if ($this->hasIncluded()) {
+            $this->included = $this->getIncluded()->sortBy($callback, $options, $descending);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasIncluded(): bool
+    {
+        return !$this->getIncluded()->isEmpty();
+    }
+
+    /**
+     * @return \Swis\JsonApi\Collection
+     */
+    public function getIncluded(): Collection
+    {
+        return $this->included ?: new Collection();
+    }
+
+    /**
+     * @param \Swis\JsonApi\Interfaces\DataInterface $included
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return static
+     */
+    public function associate(DataInterface $included)
+    {
+        if (!$included instanceof Collection) {
+            throw new \InvalidArgumentException('HasMany expects relation to be a collection');
+        }
+
+        $this->included = $included;
+
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return static
+     * @throws \LogicException
+     */
+    public function setType(string $type)
+    {
+        throw new \LogicException('Type is not set in a MorphToMany-relationships');
+    }
+
+    /**
+     * @return static
+     */
+    public function dissociate()
+    {
+        $this->included = null;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $omitIncluded
+     *
+     * @return static
+     */
+    public function setOmitIncluded(bool $omitIncluded)
+    {
+        $this->omitIncluded = $omitIncluded;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldOmitIncluded(): bool
+    {
+        return $this->omitIncluded;
+    }
+}

--- a/src/Relations/MorphToManyRelation.php
+++ b/src/Relations/MorphToManyRelation.php
@@ -21,10 +21,14 @@ class MorphToManyRelation implements RelationInterface
      */
     protected $omitIncluded = false;
 
-
+    /**
+     * @throws \LogicException
+     *
+     * @return string
+     */
     public function getType(): string
     {
-        throw new \LogicException('Type is not set in a MorphToMany-relationships');
+        throw new \LogicException('Type is not set in a MorphToMany-relationship');
     }
 
     /**
@@ -76,7 +80,7 @@ class MorphToManyRelation implements RelationInterface
     public function associate(DataInterface $included)
     {
         if (!$included instanceof Collection) {
-            throw new \InvalidArgumentException('HasMany expects relation to be a collection');
+            throw new \InvalidArgumentException('MorphToMany expects relation to be a collection');
         }
 
         $this->included = $included;
@@ -87,8 +91,9 @@ class MorphToManyRelation implements RelationInterface
     /**
      * @param string $type
      *
-     * @return static
      * @throws \LogicException
+     *
+     * @return static
      */
     public function setType(string $type)
     {

--- a/src/Relations/MorphToRelation.php
+++ b/src/Relations/MorphToRelation.php
@@ -34,7 +34,6 @@ class MorphToRelation implements RelationInterface
     protected $omitIncluded = false;
 
     /**
-     * @param string                             $type
      * @param \Swis\JsonApi\Items\JenssegersItem $item
      */
     public function __construct(JenssegersItem $item)
@@ -52,7 +51,7 @@ class MorphToRelation implements RelationInterface
     public function associate(DataInterface $included)
     {
         if (!$included instanceof JenssegersItem) {
-            throw new \InvalidArgumentException('HasOne expects relation to be a JenssegersItem');
+            throw new \InvalidArgumentException('MorphTo expects relation to be a JenssegersItem');
         }
 
         $this->setId($included->getId());

--- a/src/Relations/MorphToRelation.php
+++ b/src/Relations/MorphToRelation.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Swis\JsonApi\Relations;
+
+use Swis\JsonApi\Interfaces\DataInterface;
+use Swis\JsonApi\Interfaces\RelationInterface;
+use Swis\JsonApi\Items\JenssegersItem;
+
+class MorphToRelation implements RelationInterface
+{
+    /**
+     * @var \Swis\JsonApi\Items\JenssegersItem
+     */
+    protected $included;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var \Swis\JsonApi\Items\JenssegersItem
+     */
+    protected $parentItem;
+
+    /**
+     * @var bool
+     */
+    protected $omitIncluded = false;
+
+    /**
+     * @param string                             $type
+     * @param \Swis\JsonApi\Items\JenssegersItem $item
+     */
+    public function __construct(JenssegersItem $item)
+    {
+        $this->parentItem = $item;
+    }
+
+    /**
+     * @param \Swis\JsonApi\Interfaces\DataInterface $included
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return static
+     */
+    public function associate(DataInterface $included)
+    {
+        if (!$included instanceof JenssegersItem) {
+            throw new \InvalidArgumentException('HasOne expects relation to be a JenssegersItem');
+        }
+
+        $this->setId($included->getId());
+        $this->setType($included->getType());
+
+        $this->included = $included;
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    public function dissociate()
+    {
+        $this->included = null;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $id
+     *
+     * @return static
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return static
+     */
+    public function setType(string $type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return \Swis\JsonApi\Items\JenssegersItem|null
+     */
+    public function getIncluded()
+    {
+        return $this->included;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasIncluded(): bool
+    {
+        return null !== $this->included;
+    }
+
+    /**
+     * @param bool $omitIncluded
+     *
+     * @return static
+     */
+    public function setOmitIncluded(bool $omitIncluded)
+    {
+        $this->omitIncluded = $omitIncluded;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldOmitIncluded(): bool
+    {
+        return $this->omitIncluded;
+    }
+}

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -169,4 +169,44 @@ class ItemHydratorTest extends AbstractTest
         $this->assertEquals('related-item', $morphTo->getType());
         $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
     }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_items_with_morphtomany_relationship()
+    {
+        $data = [
+            'testattribute1'       => 'test',
+            'testattribute2'       => 'test2',
+            'morphtomany_relation' => [
+                [
+                    'id'                      => 1,
+                    'type'                    => 'related-item',
+                    'test_related_attribute1' => 'test',
+                ],
+                [
+                    'id'                      => 2,
+                    'type'                    => 'related-item',
+                    'test_related_attribute1' => 'test',
+                ],
+            ],
+        ];
+
+        $item = new WithRelationshipJenssegersItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        $morphTo = $item->getRelationship('morphtomany_relation');
+
+        $this->assertInstanceOf(
+            \Swis\JsonApi\Relations\MorphToManyRelation::class,
+            $morphTo
+        );
+        $this->assertEquals($data['testattribute1'], $item->getAttribute('testattribute1'));
+        $this->assertEquals($data['testattribute2'], $item->getAttribute('testattribute2'));
+
+
+        $this->assertEquals('related-item', $morphTo->getIncluded()[0]->getType());
+        $this->assertEquals('related-item', $morphTo->getIncluded()[1]->getType());
+        $this->assertArrayHasKey('morphtomany_relation', $item->toJsonApiArray()['relationships']);
+    }
 }

--- a/tests/JsonApi/HydratorTest.php
+++ b/tests/JsonApi/HydratorTest.php
@@ -69,10 +69,32 @@ class HydratorTest extends AbstractTest
                     'active'      => true,
                 ],
                 'relationships' => [
-                    'child' => [
+                    'child'     => [
                         'data' => [
                             'type' => 'child',
                             'id'   => '2',
+                        ],
+                    ],
+                    'morph'     => [
+                        'data' => [
+                            'type' => 'child',
+                            'id'   => '3',
+                        ],
+                    ],
+                    'morphmany' => [
+                        'data' => [
+                            [
+                                'type' => 'child',
+                                'id'   => '4',
+                            ],
+                            [
+                                'type' => 'child',
+                                'id'   => '5',
+                            ],
+                            [
+                                'type' => 'child',
+                                'id'   => '6',
+                            ],
                         ],
                     ],
                 ],
@@ -83,6 +105,38 @@ class HydratorTest extends AbstractTest
                     'id'         => '2',
                     'attributes' => [
                         'description' => 'test',
+                        'active'      => true,
+                    ],
+                ],
+                [
+                    'type'       => 'child',
+                    'id'         => '3',
+                    'attributes' => [
+                        'description' => 'test3',
+                        'active'      => true,
+                    ],
+                ],
+                [
+                    'type'       => 'child',
+                    'id'         => '4',
+                    'attributes' => [
+                        'description' => 'test4',
+                        'active'      => true,
+                    ],
+                ],
+                [
+                    'type'       => 'child',
+                    'id'         => '5',
+                    'attributes' => [
+                        'description' => 'test5',
+                        'active'      => true,
+                    ],
+                ],
+                [
+                    'type'       => 'child',
+                    'id'         => '6',
+                    'attributes' => [
+                        'description' => 'test6',
                         'active'      => true,
                     ],
                 ],
@@ -174,5 +228,55 @@ class HydratorTest extends AbstractTest
         static::assertInstanceOf(\Swis\JsonApi\Items\JenssegersItem::class, $item);
         static::assertEquals($type, $item->getType());
         static::assertEquals($id, $item->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_a_morph_to_relation()
+    {
+        // Register the mocked type
+        /** @var \Swis\JsonApi\Interfaces\TypeMapperInterface $typeMapper */
+        $typeMapper = new \Swis\JsonApi\TypeMapper();
+        $typeMapper->setMapping('child', ChildJenssegersItem::class);
+        $typeMapper->setMapping('master', MasterJenssegersItem::class);
+        $hydrator = new \Swis\JsonApi\JsonApi\Hydrator($typeMapper);
+
+        $childItem = $hydrator->hydrateItem($this->getJsonApiItemMock('child', 3), null);
+        $included = new \Swis\JsonApi\Collection([$childItem]);
+        $masterItem = $hydrator->hydrateItem($this->getJsonApiItemMock('master', 1), $included);
+
+        static::assertInstanceOf(\Swis\JsonApi\Relations\MorphToRelation::class, $masterItem->getRelationship('morph'));
+
+        static::assertEquals('child', $masterItem->getRelationship('morph')->getType());
+        static::assertEquals(3, $masterItem->getRelationship('morph')->getId());
+
+        static::assertEquals(3, $masterItem->morph->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_a_morph_to_many_relation()
+    {
+        // Register the mocked type
+        /** @var \Swis\JsonApi\Interfaces\TypeMapperInterface $typeMapper */
+        $typeMapper = new \Swis\JsonApi\TypeMapper();
+        $typeMapper->setMapping('child', ChildJenssegersItem::class);
+        $typeMapper->setMapping('master', MasterJenssegersItem::class);
+        $hydrator = new \Swis\JsonApi\JsonApi\Hydrator($typeMapper);
+
+        $childItem = $hydrator->hydrateItem($this->getJsonApiItemMock('child', 4), null);
+        $included = new \Swis\JsonApi\Collection([$childItem]);
+        $masterItem = $hydrator->hydrateItem($this->getJsonApiItemMock('master', 1), $included);
+
+        static::assertInstanceOf(\Swis\JsonApi\Relations\MorphToManyRelation::class, $masterItem->getRelationship('morphmany'));
+
+        static::assertEquals('child', $masterItem->getRelationship('morphmany')->getIncluded()[0]->getType());
+        static::assertEquals(4, $masterItem->getRelationship('morphmany')->getIncluded()[0]->getId());
+
+        static::assertEquals(4, $masterItem->morphmany[0]->getId());
+
+
     }
 }

--- a/tests/_mocks/Items/Jenssegers/AnotherRelatedJenssegersItem.php
+++ b/tests/_mocks/Items/Jenssegers/AnotherRelatedJenssegersItem.php
@@ -1,0 +1,17 @@
+<?php
+
+class AnotherRelatedJenssegersItem extends \Swis\JsonApi\Items\JenssegersItem
+{
+    /**
+     * @var string
+     */
+    protected $type = 'another-related-item';
+
+    /**
+     * @var array
+     */
+    protected $visible = [
+        'test_related_attribute1',
+        'test_related_attribute2',
+    ];
+}

--- a/tests/_mocks/Items/Jenssegers/MasterJenssegersItem.php
+++ b/tests/_mocks/Items/Jenssegers/MasterJenssegersItem.php
@@ -35,10 +35,22 @@ class MasterJenssegersItem extends \Swis\JsonApi\Items\JenssegersItem
      */
     protected $availableRelations = [
         'child',
+        'morph',
+        'morphmany',
     ];
 
     public function child()
     {
         return $this->hasOne(ChildJenssegersItem::class);
+    }
+
+    public function morph()
+    {
+        return $this->morphTo();
+    }
+
+    public function morphmany()
+    {
+        return $this->morphToMany();
     }
 }

--- a/tests/_mocks/Items/Jenssegers/WithRelationshipJenssegersItem.php
+++ b/tests/_mocks/Items/Jenssegers/WithRelationshipJenssegersItem.php
@@ -22,6 +22,7 @@ class WithRelationshipJenssegersItem extends \Swis\JsonApi\Items\JenssegersItem
         'hasone_relation',
         'hasmany_relation',
         'morphto_relation',
+        'morphtomany_relation',
     ];
 
     public function hasoneRelation()
@@ -37,5 +38,10 @@ class WithRelationshipJenssegersItem extends \Swis\JsonApi\Items\JenssegersItem
     public function morphtoRelation()
     {
         return $this->morphTo();
+    }
+
+    public function morphtomanyRelation()
+    {
+        return $this->morphToMany();
     }
 }

--- a/tests/_mocks/Items/Jenssegers/WithRelationshipJenssegersItem.php
+++ b/tests/_mocks/Items/Jenssegers/WithRelationshipJenssegersItem.php
@@ -21,6 +21,7 @@ class WithRelationshipJenssegersItem extends \Swis\JsonApi\Items\JenssegersItem
     protected $availableRelations = [
         'hasone_relation',
         'hasmany_relation',
+        'morphto_relation',
     ];
 
     public function hasoneRelation()
@@ -31,5 +32,10 @@ class WithRelationshipJenssegersItem extends \Swis\JsonApi\Items\JenssegersItem
     public function hasmanyRelation()
     {
         return $this->hasMany(RelatedJenssegersItem::class);
+    }
+
+    public function morphtoRelation()
+    {
+        return $this->morphTo();
     }
 }


### PR DESCRIPTION
Please see the test for a small example. 

Basically, it checks for the "type" key in the data-array and uses that value for the mapping. Nothing dramatically rewritten.