### PR TITLE
Added support for dynamic/unknown relationships

### DIFF
--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -251,6 +251,12 @@ class JenssegersItem extends Model implements ItemInterface
         if (method_exists($this, $key)) {
             return $this->$key()->getIncluded();
         }
+
+        // If the "attribute" exists as a relationship on the model, we will return
+        // the included items in the relationship
+        if ($this->hasRelationship($key)) {
+            return $this->getRelationship($key)->getIncluded();
+        }
     }
 
     /**
@@ -434,8 +440,16 @@ class JenssegersItem extends Model implements ItemInterface
      */
     public function setRelation($relation, $value)
     {
-        /** @var \Swis\JsonApi\Interfaces\RelationInterface $relationObject */
-        $relationObject = $this->$relation();
+        if (method_exists($this, $relation)) {
+            /** @var \Swis\JsonApi\Interfaces\RelationInterface $relationObject */
+            $relationObject = $this->$relation();
+        } else {
+            if ($value instanceof Collection) {
+                $relationObject = $this->morphToMany($relation);
+            } else {
+                $relationObject = $this->morphTo($relation);
+            }
+        }
 
         $relationObject->associate($value);
 

--- a/src/JsonApi/Hydrator.php
+++ b/src/JsonApi/Hydrator.php
@@ -110,20 +110,18 @@ class Hydrator
             $data = $relationship->get('data');
             $method = camel_case($name);
 
-            if (method_exists($item, $method)) {
-                if ($data->isIdentifier()) {
-                    $includedItem = $this->getIncludedItem($included, $data);
+            if ($data->isIdentifier()) {
+                $includedItem = $this->getIncludedItem($included, $data);
 
-                    if ($includedItem instanceof NullItem) {
-                        continue;
-                    }
-
-                    $item->setRelation($method, $includedItem);
-                } elseif ($data->isCollection()) {
-                    $collection = $this->getIncludedItems($included, $data);
-
-                    $item->setRelation($method, $collection);
+                if ($includedItem instanceof NullItem) {
+                    continue;
                 }
+
+                $item->setRelation($method, $includedItem);
+            } elseif ($data->isCollection()) {
+                $collection = $this->getIncludedItems($included, $data);
+
+                $item->setRelation($method, $collection);
             }
         }
 

--- a/tests/JsonApi/HydratorTest.php
+++ b/tests/JsonApi/HydratorTest.php
@@ -13,6 +13,7 @@ use Swis\JsonApi\Relations\MorphToRelation;
 use Swis\JsonApi\Tests\AbstractTest;
 use Swis\JsonApi\Tests\Mocks\Items\Jenssegers\ChildJenssegersItem;
 use Swis\JsonApi\Tests\Mocks\Items\Jenssegers\MasterJenssegersItem;
+use Swis\JsonApi\Tests\Mocks\Items\Jenssegers\WithoutRelationshipsJenssegersItem;
 use Swis\JsonApi\TypeMapper;
 
 /**
@@ -284,6 +285,52 @@ class HydratorTest extends AbstractTest
         $childItem = $hydrator->hydrateItem($this->getJsonApiItemMock('child', 4), null);
         $included = new Collection([$childItem]);
         $masterItem = $hydrator->hydrateItem($this->getJsonApiItemMock('master', 1), $included);
+
+        static::assertInstanceOf(MorphToManyRelation::class, $masterItem->getRelationship('morphmany'));
+
+        static::assertEquals('child', $masterItem->getRelationship('morphmany')->getIncluded()[0]->getType());
+        static::assertEquals(4, $masterItem->getRelationship('morphmany')->getIncluded()[0]->getId());
+
+        static::assertEquals(4, $masterItem->morphmany[0]->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_an_unknown_relation_as_morph_to()
+    {
+        // Register the mocked type
+        /** @var \Swis\JsonApi\Interfaces\TypeMapperInterface $typeMapper */
+        $typeMapper = new TypeMapper();
+        $typeMapper->setMapping('item-without-relationships', WithoutRelationshipsJenssegersItem::class);
+        $hydrator = new Hydrator($typeMapper);
+
+        $childItem = $hydrator->hydrateItem($this->getJsonApiItemMock('child', 3), null);
+        $included = new Collection([$childItem]);
+        $masterItem = $hydrator->hydrateItem($this->getJsonApiItemMock('item-without-relationships', 1), $included);
+
+        static::assertInstanceOf(MorphToRelation::class, $masterItem->getRelationship('morph'));
+
+        static::assertEquals('child', $masterItem->getRelationship('morph')->getType());
+        static::assertEquals(3, $masterItem->getRelationship('morph')->getId());
+
+        static::assertEquals(3, $masterItem->morph->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_an_unknown_relation_as_morph_to_many()
+    {
+        // Register the mocked type
+        /** @var \Swis\JsonApi\Interfaces\TypeMapperInterface $typeMapper */
+        $typeMapper = new TypeMapper();
+        $typeMapper->setMapping('item-without-relationships', WithoutRelationshipsJenssegersItem::class);
+        $hydrator = new Hydrator($typeMapper);
+
+        $childItem = $hydrator->hydrateItem($this->getJsonApiItemMock('child', 4), null);
+        $included = new Collection([$childItem]);
+        $masterItem = $hydrator->hydrateItem($this->getJsonApiItemMock('item-without-relationships', 1), $included);
 
         static::assertInstanceOf(MorphToManyRelation::class, $masterItem->getRelationship('morphmany'));
 

--- a/tests/_mocks/Items/Jenssegers/WithoutRelationshipsJenssegersItem.php
+++ b/tests/_mocks/Items/Jenssegers/WithoutRelationshipsJenssegersItem.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Swis\JsonApi\Tests\Mocks\Items\Jenssegers;
+
+use Swis\JsonApi\Items\JenssegersItem;
+
+class WithoutRelationshipsJenssegersItem extends JenssegersItem
+{
+    /**
+     * @var string
+     */
+    protected $type = 'item-without-relationships';
+}


### PR DESCRIPTION
If a relationship is not defined on the item, it will still be hydrated.