### PR TITLE
Hydrate HasManyRelation by id

### DIFF
--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -134,7 +134,11 @@ class ItemHydrator
     protected function hydrateHasManyRelation(array $attributes, string $availableRelation, HasManyRelation $relation)
     {
         foreach ($attributes[$availableRelation] as $relationData) {
-            $relationItem = $this->buildRelationItem($relation, $relationData);
+            if (is_array($relationData)) {
+                $relationItem = $this->buildRelationItem($relation, $relationData);
+            } else {
+                $relationItem = $this->buildRelationItem($relation, ['id' => $relationData]);
+            }
 
             $relation->associate($relation->getIncluded()->push($relationItem));
         }

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -299,4 +299,47 @@ class ItemHydratorTest extends AbstractTest
         $this->assertEquals($data['hasone_relation']['parent_relation'], $hasOneParent->getId());
         $this->assertEquals('item-with-relationship', $hasOneParent->getType());
     }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_a_hasmany_relationship_by_id()
+    {
+        $data = [
+            'testattribute1'   => 'test',
+            'testattribute2'   => 'test2',
+            'hasmany_relation' => [
+                1,
+                2,
+            ],
+        ];
+
+        $item = new WithRelationshipJenssegersItem();
+
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+        /** @var \Swis\JsonApi\Relations\HasManyRelation $hasMany */
+        $hasMany = $item->getRelationship('hasmany_relation');
+
+        $this->assertInstanceOf(
+            HasManyRelation::class,
+            $hasMany
+        );
+
+        $this->assertInstanceOf(Collection::class, $hasMany->getIncluded());
+        $this->assertCount(2, $hasMany->getIncluded());
+
+        $expected = [
+            [
+                'id'         => 1,
+                'type'       => 'related-item',
+            ],
+            [
+                'id'         => 2,
+                'type'       => 'related-item',
+            ],
+        ];
+
+        $this->assertEquals($expected, $hasMany->getIncluded()->toJsonApiArray());
+        $this->assertArrayHasKey('hasmany_relation', $item->toJsonApiArray()['relationships']);
+    }
 }


### PR DESCRIPTION
A HasManyRelation can also be hydrated by providing only the id of the relationship, just like a HasOneRelation