### PR TITLE
200 > is successful, return guzzleResponse from response

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -8,15 +8,6 @@ use Swis\JsonApi\Interfaces\ResponseInterface;
 class Response implements ResponseInterface
 {
     /**
-     * @var array
-     */
-    protected $successfulStatusCodes = [
-        200,
-        202,
-        204,
-    ];
-
-    /**
      * @var \GuzzleHttp\Psr7\Response
      */
     private $guzzleResponse;
@@ -34,7 +25,7 @@ class Response implements ResponseInterface
      */
     public function hasSuccessfulStatusCode(): bool
     {
-        return in_array($this->guzzleResponse->getStatusCode(), $this->successfulStatusCodes, false);
+        return $this->guzzleResponse->getStatusCode() >= 200 && $this->guzzleResponse->getStatusCode() < 300;
     }
 
     /**
@@ -43,6 +34,14 @@ class Response implements ResponseInterface
     public function hasServerErrorStatusCode(): bool
     {
         return $this->guzzleResponse->getStatusCode() >= 500 && $this->guzzleResponse->getStatusCode() < 600;
+    }
+
+    /**
+     * @return GuzzleResponse
+     */
+    public function getGuzzleResponse(): GuzzleResponse
+    {
+        return $this->guzzleResponse;
     }
 
     /**

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -19,5 +19,6 @@ class ResponseFactoryTest extends AbstractTest
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(true, $response->hasSuccessfulStatusCode());
         $this->assertEquals('test response', $response->getBody());
+        $this->assertEquals($psrResponse, $response->getGuzzleResponse());
     }
 }


### PR DESCRIPTION
- All `>= 200 && < 300` codes are now treated as successful
- The Response can now return the original Guzzle response `getGuzzleResponse()`